### PR TITLE
US626012: Release preparation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2022-2023 Micro Focus or one of its affiliates.
+    Copyright 2022-2023 Open Text.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common-parent</artifactId>
-        <version>3.0.0-318</version>
+        <version>4.1.0-380</version>
     </parent>
 
     <licenses>
@@ -71,6 +71,7 @@
         <dockerCafImagePrefix>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerCafImagePrefix>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <DOCKER_HUB_PUBLIC>${dockerHubPublic}</DOCKER_HUB_PUBLIC>
+        <enforceBannedDependencies>false</enforceBannedDependencies>
     </properties>
 
     <dependencyManagement>

--- a/release-notes-2.1.0.md
+++ b/release-notes-2.1.0.md
@@ -1,5 +1,3 @@
-!not-ready-for-release!
-
 #### Version Number
 ${version-number}
 
@@ -7,3 +5,4 @@ ${version-number}
 - US628005: Updated OpenSearch to version [1.3.8](https://opensearch.org/versions/opensearch-1-3-8.html)
 
 #### Known Issues
+- None

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2022-2023 Micro Focus or one of its affiliates.
+# Copyright 2022-2023 Open Text.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/docker/log4j2.properties
+++ b/src/main/docker/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2022-2023 Micro Focus or one of its affiliates.
+# Copyright 2022-2023 Open Text.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/docker/scripts/start.sh
+++ b/src/main/docker/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2022-2023 Micro Focus or one of its affiliates.
+# Copyright 2022-2023 Open Text.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/cafapi/opensuse/opensearch1/ContainerIT.java
+++ b/src/test/java/com/github/cafapi/opensuse/opensearch1/ContainerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Micro Focus or one of its affiliates.
+ * Copyright 2022-2023 Open Text.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2022-2023 Micro Focus or one of its affiliates.
+# Copyright 2022-2023 Open Text.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Had to overwrite the enforceBannedDependencies as log4j-core was being flagged.