### PR TITLE
US902060: Addressing CVE issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,12 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.16.0</version>
+                <version>2.23.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.16.0</version>
+                <version>2.23.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -100,14 +100,14 @@
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <!-- version clashes with analysis-icu plugin -->
-                <exclusion>
+                <!--<exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-text</artifactId>
-                </exclusion>
+                </exclusion>-->
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
                     <environmentVariables>
                         <OPENSEARCH_HOST>${docker.host.address}</OPENSEARCH_HOST>
                         <OPENSEARCH_PORT>${os.http.port}</OPENSEARCH_PORT>
-                        <OPENSEARCH_SCHEME>https</OPENSEARCH_SCHEME>
+                        <OPENSEARCH_SCHEME>http</OPENSEARCH_SCHEME>
                     </environmentVariables>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -100,14 +100,14 @@
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <!-- version clashes with analysis-icu plugin -->
-                <!--<exclusion>
+                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-text</artifactId>
-                </exclusion>-->
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/release-notes-3.0.0.md
+++ b/release-notes-3.0.0.md
@@ -13,6 +13,7 @@ ${version-number}
   - opensearch-knn
   - opensearch-sql
   - opensearch-observability
+  - opensearch-security
 
 #### New Features
 - US896108: Updated OpenSearch to version [1.3.15](https://opensearch.org/versions/opensearch-1-3-15.html)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -30,7 +30,8 @@ RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-an
     /usr/share/opensearch/bin/opensearch-plugin remove opensearch-asynchronous-search && \
     /usr/share/opensearch/bin/opensearch-plugin remove opensearch-knn && \
     /usr/share/opensearch/bin/opensearch-plugin remove opensearch-sql && \
-    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-observability --purge
+    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-observability --purge && \
+    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security
 
 
 RUN rm -rf /usr/share/opensearch/jdk \
@@ -103,6 +104,6 @@ RUN chmod +x /opt/opensearch/scripts/*
 # Startup opensearch and expose ports
 EXPOSE 9200 9300
 
-HEALTHCHECK --interval=1m --start-period=5m CMD curl -k -u "admin:admin" https://0.0.0.0:9200 || exit 1
+HEALTHCHECK --interval=1m --start-period=5m CMD curl -k http://0.0.0.0:9200 || exit 1
 
 CMD /opt/opensearch/scripts/start.sh

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -34,7 +34,8 @@ RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-an
 
 
 RUN rm -rf /usr/share/opensearch/jdk \
-           /usr/share/opensearch/lib/log4j-*
+           /usr/share/opensearch/lib/log4j-* \
+           /usr/share/opensearch/performance-analyzer-rca
 
 #
 # Builder image to install plugins and configure opensearch


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=902060

Updated log4j jars to 2.23.1 and removed the "/usr/share/opensearch/performance-analyzer-rca" folder as it is only needed if the performance analyzer plugin is installed.

opensearch-security plugin also removed, as part of that needed to change healthcheck to http with no credentials.

Image is tested here:
- https://github.houston.softwaregrp.net/Verity/worker-classification/pull/272
  - Test failures are related to removal of family hashing fields, being dealt with in [US892120](https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=892120)
- https://github.houston.softwaregrp.net/Verity/worker-classification/pull/273