### PR TITLE
US902060: Addressing Jackson and Netty CVE issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,76 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-smile</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>4.1.108.Final</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>2.23.1</version>
@@ -90,6 +160,22 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.github.cafapi.logging</groupId>
             <artifactId>caf-logging-log4j2</artifactId>
@@ -109,6 +195,38 @@
                     <artifactId>commons-text</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opensearch.client</groupId>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -36,7 +36,11 @@ RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-an
 
 RUN rm -rf /usr/share/opensearch/jdk \
            /usr/share/opensearch/lib/log4j-* \
-           /usr/share/opensearch/performance-analyzer-rca
+           /usr/share/opensearch/performance-analyzer-rca \
+           /usr/share/opensearch/lib/jackson-* \
+           /usr/share/opensearch/lib/tools/upgrade-cli/jackson-* \
+           /usr/share/opensearch/modules/ingest-geoip/jackson-* \
+           /usr/share/opensearch/modules/transport-netty4/netty-*
 
 #
 # Builder image to install plugins and configure opensearch
@@ -63,7 +67,21 @@ COPY --from=os1-image --chown=1000:0 /usr/share/opensearch/ /usr/share/opensearc
 
 # Configure logging
 COPY log4j2.properties /usr/share/opensearch/config
-COPY /maven/*.jar /usr/share/opensearch/lib/
+COPY /maven/log4j-*.jar /usr/share/opensearch/lib/
+
+# Copy updated jackson jars
+COPY /maven/jackson-core-*.jar /usr/share/opensearch/lib/
+COPY /maven/jackson-dataformat-cbor-*.jar /usr/share/opensearch/lib/
+COPY /maven/jackson-dataformat-smile-*.jar /usr/share/opensearch/lib/
+COPY /maven/jackson-dataformat-yaml-*.jar /usr/share/opensearch/lib/
+COPY /maven/jackson-annotations-*.jar /usr/share/opensearch/lib/tools/upgrade-cli/
+COPY /maven/jackson-core-*.jar /usr/share/opensearch/lib/tools/upgrade-cli/
+COPY /maven/jackson-databind-*.jar /usr/share/opensearch/lib/tools/upgrade-cli/
+COPY /maven/jackson-annotations-*.jar /usr/share/opensearch/modules/ingest-geoip/
+COPY /maven/jackson-databind-*.jar /usr/share/opensearch/modules/ingest-geoip/
+
+# Copy updated netty jars
+COPY /maven/netty-*.jar /usr/share/opensearch/modules/transport-netty4/
 
 # Install ICU Analysis plugin
 RUN JAVA_HOME=${JRE_HOME} OPENSEARCH_JAVA_OPTS="$(echo ${https_proxy} | sed -E 's/^.*:\/\/(.*):([0-9]*).*/-Dhttps.proxyHost=\1 -Dhttps.proxyPort=\2/')" \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -68,6 +68,8 @@ COPY --from=os1-image --chown=1000:0 /usr/share/opensearch/ /usr/share/opensearc
 # Configure logging
 COPY log4j2.properties /usr/share/opensearch/config
 COPY /maven/log4j-*.jar /usr/share/opensearch/lib/
+COPY /maven/caf-logging-*.jar /usr/share/opensearch/lib/
+COPY /maven/util-process-identifier-*.jar /usr/share/opensearch/lib/
 
 # Copy updated jackson jars
 COPY /maven/jackson-core-*.jar /usr/share/opensearch/lib/


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=902060

I am concerned with these log entries after this change:
```
2024-04-05T10:05:34.914066122Z f2716f> 2024-04-05T10:05:34.909190914Z main ERROR Unrecognized format specifier [sanitize]
2024-04-05T10:05:34.914086906Z f2716f> 2024-04-05T10:05:34.911250685Z main ERROR Unrecognized conversion specifier [sanitize] starting at position 75 in conversion pattern.
2024-04-05T10:05:34.914092462Z f2716f> 2024-04-05T10:05:34.911446406Z main ERROR Unrecognized format specifier [sanitize]
2024-04-05T10:05:34.914096640Z f2716f> 2024-04-05T10:05:34.911597678Z main ERROR Unrecognized conversion specifier [sanitize] starting at position 113 in conversion pattern.
2024-04-05T10:05:34.914346581Z f2716f> 2024-04-05T10:05:34.911794236Z main ERROR Unrecognized format specifier [sanitize]
2024-04-05T10:05:34.914359117Z f2716f> 2024-04-05T10:05:34.911939480Z main ERROR Unrecognized conversion specifier [sanitize] starting at position 139 in conversion pattern.
```
However the image builds fine and works with classification worker here: https://github.houston.softwaregrp.net/Verity/worker-classification/pull/277