### PR TITLE
I907068: Update to latest Java 17 base image

### DIFF
--- a/release-notes-3.0.1.md
+++ b/release-notes-3.0.1.md
@@ -4,8 +4,8 @@ ${version-number}
 #### New Features
 - None
 
-#### Patch Fixes Included
-- This release includes OS package updates only.
+#### Bug Fixes
+- I907068: Fixed issue with non-root users being unable to write to the NSS directory.
 
 #### Known Issues
 - None

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -99,7 +99,7 @@ RUN chgrp 0 /usr/share/opensearch/opensearch-docker-entrypoint.sh && \
 #
 # The actual image definition
 #
-FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-I907068-perms-SNAPSHOT
+FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-SNAPSHOT
 
 RUN zypper -n refresh && \
     zypper -n update && \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN rm -rf /usr/share/opensearch/jdk \
 #
 # Builder image to install plugins and configure opensearch
 #
-FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-I907068-perms-SNAPSHOT-1 AS builder
+FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-I907068-perms-SNAPSHOT AS builder
 
 RUN zypper -n refresh && \
     zypper -n update
@@ -99,7 +99,7 @@ RUN chgrp 0 /usr/share/opensearch/opensearch-docker-entrypoint.sh && \
 #
 # The actual image definition
 #
-FROM @DOCKER_HUB_PUBLIC@/cafapi/opensuse-jre17:1
+FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-I907068-perms-SNAPSHOT
 
 RUN zypper -n refresh && \
     zypper -n update && \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN rm -rf /usr/share/opensearch/jdk \
 #
 # Builder image to install plugins and configure opensearch
 #
-FROM @DOCKER_HUB_PUBLIC@/cafapi/opensuse-jre17:1 AS builder
+FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-I907068-perms-SNAPSHOT-1 AS builder
 
 RUN zypper -n refresh && \
     zypper -n update

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN rm -rf /usr/share/opensearch/jdk \
 #
 # Builder image to install plugins and configure opensearch
 #
-FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-I907068-perms-SNAPSHOT AS builder
+FROM @DOCKER_HUB_PUBLIC@/cafapi/prereleases:opensuse-jre17-1.5.1-SNAPSHOT AS builder
 
 RUN zypper -n refresh && \
     zypper -n update


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=907068

Prior to a recent Java update, the `/usr/lib64/jvm/java-17-openjdk-17/conf/security/nss.fips.cfg` file had the following property:

```
nssDbMode=readOnly
```

and the `/etc/pki/nssdb` dir has the following perms:

```
drwxr-xr-x. 1 root root    37 Mar  8 13:35 .
drwxr-xr-x. 1 root root    32 Apr  8 08:40 ..
-rw-r--r--. 1 root root 28672 Mar  8 13:35 cert9.db
-rw-r--r--. 1 root root 36864 Mar  8 13:35 key4.db
-rw-r--r--. 1 root root   421 Mar  8 13:35 pkcs11.txt
```

However, in newer versions of Java (such as `build 17.0.10+7-suse-150400.3.39.2-x8664`), this has changed to:

```
nssDbMode=readWrite
```

which means services running as non-root can no longer access the NSS db, so I have changed the permissions to:

```
drwxr-xr-x. 1 root root    55 Mar  8 13:35 .
drwxr-xr-x. 1 root root    32 Apr  8 08:40 ..
-rw-rw-rw-. 1 root root 28672 Mar  8 13:35 cert9.db
-rw-rw-rw-. 1 root root 36864 Mar  8 13:35 key4.db
-rw-rw-rw-. 1 root root   421 Mar  8 13:35 pkcs11.txt
```